### PR TITLE
Disable caching streamed volumes

### DIFF
--- a/terraform/environments/production/ci-values.yml.tpl
+++ b/terraform/environments/production/ci-values.yml.tpl
@@ -114,6 +114,7 @@ concourse:
     containerPlacementStrategy: limit-active-tasks
     limitActiveTasks: 5
     streamingArtifactsCompression: zstd
+    disableCacheStreamedVolumes: true
     enableGlobalResources: true
     enableAcrossStep: true
     enablePipelineInstances: true

--- a/terraform/environments/production/ci-values.yml.tpl
+++ b/terraform/environments/production/ci-values.yml.tpl
@@ -20,6 +20,8 @@ web:
     value: 127.0.0.1:55680
   - name: CONCOURSE_TRACING_OTLP_USE_TLS
     value: "false"
+  - name: CONCOURSE_DISABLE_CACHE_STREAMED_VOLUMES
+    value: "true"
 
   resources:
     requests:
@@ -114,7 +116,6 @@ concourse:
     containerPlacementStrategy: limit-active-tasks
     limitActiveTasks: 5
     streamingArtifactsCompression: zstd
-    disableCacheStreamedVolumes: true
     enableGlobalResources: true
     enableAcrossStep: true
     enablePipelineInstances: true


### PR DESCRIPTION
the darwin worker does not have enough disk space to store resoruce
caches + it's usual disk usage. Upgrading the mac's disk is also not
possible. We have to upgrade to a whole new mac mini with a larger disk.

Signed-off-by: Taylor Silva <tsilva@pivotal.io>
Co-authored-by: Esteban Foronda <eforonda@vmware.com>